### PR TITLE
Remove missing GUI screenshot reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ ScanImage Z Control provides a user-friendly GUI and robust backend for controll
 
 This solution is particularly useful for microscopy setups where ScanImage's built-in Z control methods are unreliable or limited.
 
-![GUI Screenshot](docs/images/gui_screenshot.png)
 
 ## Repository Structure
 


### PR DESCRIPTION
### **User description**
## Summary
- remove the README's reference to a non-existent screenshot

## Testing
- `matlab -batch "run('tests/test_zcontrol.m')"` *(fails: `matlab` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413a6e12e083279b3185d5d3635193


___

### **PR Type**
Documentation


___

### **Description**
- Removed reference to a missing GUI screenshot in README

- Improved README accuracy by eliminating broken image link


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Remove missing GUI screenshot reference from README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Deleted reference to non-existent GUI screenshot image<br> <li> Cleaned up documentation to avoid broken image links


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/scanimage-zcontrol/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>