### PR TITLE
Fix setVelocity with acceleration property

### DIFF
--- a/src/ThorlabsZControl.m
+++ b/src/ThorlabsZControl.m
@@ -258,7 +258,7 @@ classdef ThorlabsZControl < handle
             
             try
                 obj.log(sprintf('Setting velocity to: %.2f', velocity), 1);
-                obj.hC.SetVelParams(0, 0, acceleration, velocity);
+                obj.hC.SetVelParams(0, 0, obj.acceleration, velocity);
                 obj.velocity = velocity;
                 success = true;
             catch ME

--- a/tests/test_zcontrol.m
+++ b/tests/test_zcontrol.m
@@ -4,6 +4,9 @@ function test_zcontrol
 % This script tests the basic functionality of both Z control methods
 % (direct hardware and ScanImage API) to verify proper operation.
 
+% Add the src directory to the path
+addpath(fullfile(fileparts(mfilename('fullpath')), '..', 'src'));
+
 %% Test Direct Hardware Control
 fprintf('Testing ThorlabsZControl (Direct Hardware Control)...\n');
 
@@ -18,7 +21,20 @@ try
         % Get current position
         pos = z.getCurrentPosition();
         fprintf('✓ Current Z position: %.2f\n', pos);
-        
+
+        % Test setVelocity
+        fprintf('Testing setVelocity...\n');
+        try
+            successVel = z.setVelocity(z.velocity);
+            if successVel
+                fprintf('✓ setVelocity successful\n');
+            else
+                fprintf('✗ setVelocity returned false\n');
+            end
+        catch ME
+            fprintf('✗ setVelocity threw an error: %s\n', ME.message);
+        end
+
         % Test relative movement
         fprintf('Testing relative movement...\n');
         success = z.moveRelative(1.0);  % Move 1 µm up


### PR DESCRIPTION
## Summary
- fix undefined variable in `setVelocity`
- update `test_zcontrol.m` to include path setup and a check for `setVelocity`

## Testing
- `octave --no-gui --eval "run('tests/test_zcontrol.m');"` *(fails: 'actxcontrol' undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68413a674ca88327a98f4759feb2501c